### PR TITLE
Adicionar ficha catalográfica para TCC em BSI

### DIFF
--- a/tese-FT.cls
+++ b/tese-FT.cls
@@ -143,7 +143,7 @@
 %%%%
 \gdef\bsi{
 %added
-  \gdef\@textoaviso{\relax}
+  \gdef\@textoaviso{\relax \cathpage}
   \if\@autora\relax
   \gdef\@degnamept{Bacharel em Sistemas de Informação}
   \gdef\@degnamees{Licenciatura en Sistemas de Información}
@@ -486,12 +486,12 @@
 \def\cathpage{
   \ifx\@fichacatalografica\relax
   Na versão final, esta página será substituída pela
-  ficha catalográfica na dissertação de mestrado ou na
-  tese de doutorado.
+  ficha catalográfica na dissertação de mestrado,
+  tese de doutorado, ou no TCC.
   
   \phantom{linha em branco}
   
-  No caso de TCC, deixe essa página em branco conforme as instruções a seguir.
+  No caso de TCC em tads, deixe essa página em branco conforme as instruções a seguir.
   
   \phantom{linha em branco}
   

--- a/tese.tex
+++ b/tese.tex
@@ -116,8 +116,7 @@
 % copie o arquivo PDF para o projeto no Overleaf, descomente 
 % e informe o nome do arquivo no comando a seguir.
 %\fichacatalografica{SeuArquivo.pdf}
-% OBSERVAÇÂO: O comando para a ficha catalográfica só é válido 
-% em teses e dissertações (não é válido para TCC).
+% OBSERVAÇÂO: O comando para a ficha catalográfica Não é válido para tads
 %
 % Para deixar uma página em branco no lugar da ficha 
 % catalográfica, descomente uma das três linhas a seguir:


### PR DESCRIPTION
A ficha catalográfica está sendo pedida para o TCC no curso de BSI, por isso configurei para o comando ser usado no caso de BSI também